### PR TITLE
Update CCS endpoint to Wii U

### DIFF
--- a/NusClient.cs
+++ b/NusClient.cs
@@ -155,7 +155,7 @@ namespace libWiiSharp
             }
             FireProgress(0);
             string str1 = "tmd" + (string.IsNullOrEmpty(titleVersion) ? string.Empty : "." + titleVersion);
-            string str2 = string.Format("{0}{1}/", "http://nus.cdn.shop.wii.com/ccs/download/", titleId);
+            string str2 = string.Format("{0}{1}/", nusUrl, titleId);
             string empty = string.Empty;
             int contentIndex = 0;
             FireDebug("   Downloading TMD...");
@@ -233,7 +233,7 @@ namespace libWiiSharp
                 throw new Exception("You're not connected to the internet!");
             }
 
-            return TMD.Load(wcNus.DownloadData(string.Format("{0}{1}/", "http://nus.cdn.shop.wii.com/ccs/download/", titleId) + ("tmd" + (string.IsNullOrEmpty(titleVersion) ? string.Empty : "." + titleVersion))));
+            return TMD.Load(wcNus.DownloadData(string.Format("{0}{1}/", nusUrl, titleId) + ("tmd" + (string.IsNullOrEmpty(titleVersion) ? string.Empty : "." + titleVersion))));
         }
 
         private void PrivDownloadTitle(
@@ -248,7 +248,7 @@ namespace libWiiSharp
                 FireDebug("  No store types were defined...");
                 throw new Exception("You must at least define one store type!");
             }
-            string str1 = string.Format("{0}{1}/", "http://nus.cdn.shop.wii.com/ccs/download/", titleId);
+            string str1 = string.Format("{0}{1}/", nusUrl, titleId);
             bool flag1 = false;
             bool flag2 = false;
             bool flag3 = false;

--- a/NusClient.cs
+++ b/NusClient.cs
@@ -35,7 +35,7 @@ namespace libWiiSharp
 
     public class NusClient : IDisposable
     {
-        private const string nusUrl = "http://nus.cdn.shop.wii.com/ccs/download/";
+        private const string nusUrl = "http://ccs.cdn.wup.shop.nintendo.net/ccs/download/";
 #pragma warning disable SYSLIB0014 // Type or member is obsolete
         private readonly WebClient wcNus = new WebClient();
 #pragma warning restore SYSLIB0014 // Type or member is obsolete


### PR DESCRIPTION
As `ccs.shop.wii.com` and `nus.cdn.shop.wii.com` are currently down, it may be worthwhile to use the Wii U endpoint in the meantime. From testing, it appears to host the same contents as the normal Wii NUS endpoint does.

An alternative could be to use `nus.cdn.t.shop.nintendowifi.net` for the DSi.